### PR TITLE
adding doi

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ RNA count seqspec of lenti virus MPRA from shendure (UW) grant:
 
 ```bash
 python generate_seqspec.py --template templates/igvf_mpra_lenti_counts.v0.3.0.yml \
---name mpra_shendure_asd --modality rna \
+--name mpra_shendure_asd --modality rna --doi 10.3390/ijms24043509 \
 --r1-id IGVFFI2104GOOJ --r2-id IGVFFI5314QYSA --r3-id IGVFFI1100CEBW \
 --output test.yaml
 ```

--- a/generate_seqspec.py
+++ b/generate_seqspec.py
@@ -169,7 +169,7 @@ def cli(
         "r3_primer": r3_primer,
     }
 
-    if doi:
+    if doi is not None:
         template_vars["doi"] = doi
 
     def getReads(read_ids):
@@ -184,19 +184,19 @@ def cli(
 
     platform_terms = conn.get(reads[0]["sequencing_platform"]["@id"])
     template_vars["platform_terms"] = platform_terms
-    if not bc_length:
+    if bc_length is None:
         bc_length = reads[0]["mean_read_length"]
     template_vars["bc_length"] = bc_length
 
     reads = getReads(r2_ids)
     template_vars["r2_reads"] = reads
-    if not oligo_length and r2_ids:
+    if oligo_length is None and r2_ids is not None:
         oligo_length = reads[0]["mean_read_length"]
     template_vars["oligo_length"] = oligo_length
 
     template_vars["r3_reads"] = getReads(r3_ids)
 
-    if onlist_id:
+    if onlist_id is not None:
         onlist = conn.get(onlist_id)
         template_vars["onlist"] = onlist
 

--- a/generate_seqspec.py
+++ b/generate_seqspec.py
@@ -36,6 +36,13 @@ import os
     help="Modality of the data",
 )
 @click.option(
+    "--doi",
+    "doi",
+    required=False,
+    type=str,
+    help="DOI of the publication",
+)
+@click.option(
     "--bc-length",
     "bc_length",
     required=False,
@@ -115,6 +122,7 @@ def cli(
     template_file,
     name,
     modality,
+    doi,
     bc_length,
     oligo_length,
     r1_ids,
@@ -160,6 +168,9 @@ def cli(
         "r2_primer": r2_primer,
         "r3_primer": r3_primer,
     }
+
+    if doi:
+        template_vars["doi"] = doi
 
     def getReads(read_ids):
         reads = []


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced an optional command-line option `--doi` for users to specify a Digital Object Identifier (DOI) when generating seqspec files, enhancing the metadata included in the output.
	- Updated installation instructions to include the `click` package and clarified the installation of the `igvf_utils` package.
	- Enhanced the Quickstart section with updated examples for generating RNA count seqspec, improving clarity and usability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->